### PR TITLE
preserve user defined backends

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,10 +166,14 @@ class hiera (
       false => $eyaml_datadir,
       true  => $datadir,
     }
-    # the requested_backends has a side affect in that the eyaml will always be
-    # first for backend lookups.  This can be fixed by specifing the order in
-    # the backends parameter ie. ['yaml', 'eyaml', 'redis']
-    $requested_backends = unique(concat(['eyaml'], $backends))
+
+    # if eyaml is present in $backends, preserve its location!
+    if ( 'eyaml' in $backends ) {
+      $requested_backends = $backends
+    } else {
+      $requested_backends = unique(concat(['eyaml'], $backends))
+    }
+
   } else {
     $requested_backends = $backends
     $eyaml_real_datadir = undef


### PR DESCRIPTION
The following seems not being applied:

# the requested_backends has a side affect in that the eyaml will always be
# first for backend lookups.  This can be fixed by specifing the order in
# the backends parameter ie. ['yaml', 'eyaml', 'redis']

When we specify an order:
```yaml
hiera::backends:
  - consul
  - eyaml
  - yaml
```

eyaml is always included as first and the hiera.yaml generated comes as:

```yaml
:backends:
- eyaml
- consul
- yaml
``` 

The fix applied was to ignore the concat if eyaml is already present in the user defined backends.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
